### PR TITLE
Importing token list error message handled

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/containers/ManageLists/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/ManageLists/index.tsx
@@ -20,10 +20,11 @@ interface ListSearchState {
 export interface ManageListsProps {
   lists: ListState[]
   listSearchResponse: ListSearchResponse
+  isListUrlValid: boolean
 }
 
 export function ManageLists(props: ManageListsProps) {
-  const { lists, listSearchResponse } = props
+  const { lists, listSearchResponse, isListUrlValid } = props
 
   const activeTokenListsIds = useListsEnabledState()
   const addListImport = useAddListImport()
@@ -34,6 +35,9 @@ export function ManageLists(props: ManageListsProps) {
 
   return (
     <styledEl.Wrapper>
+      {isListUrlValid && !listToImport?.list && !loading && (
+        <styledEl.InputError>Error importing token list</styledEl.InputError>
+      )}
       {loading && (
         <styledEl.LoaderWrapper>
           <Loader />

--- a/apps/cowswap-frontend/src/modules/tokensList/containers/ManageLists/styled.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/ManageLists/styled.ts
@@ -18,3 +18,10 @@ export const LoaderWrapper = styled.div`
 export const ImportListsContainer = styled.div`
   border-bottom: 1px solid var(${UI.COLOR_BORDER});
 `
+
+export const InputError = styled.div`
+  padding: 20px;
+  color: var(${UI.COLOR_DANGER});
+  font-weight: 500;
+  border-bottom: 1px solid var(${UI.COLOR_BORDER});
+`

--- a/apps/cowswap-frontend/src/modules/tokensList/containers/ManageListsAndTokens/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/ManageListsAndTokens/index.tsx
@@ -38,7 +38,7 @@ export function ManageListsAndTokens(props: ManageListsAndTokensProps) {
   }, [tokenInput])
 
   const isListUrlValid = useMemo(() => {
-    if (!listInput) return true
+    if (!listInput) return false
 
     return uriToHttp(listInput).length > 0 || Boolean(parseENSAddress(listInput))
   }, [listInput])
@@ -75,11 +75,11 @@ export function ManageListsAndTokens(props: ManageListsAndTokensProps) {
           onChange={(e) => setInputValue(e.target.value)}
           placeholder={isListsTab ? listsInputPlaceholder : tokensInputPlaceholder}
         />
-        {!isListUrlValid && <styledEl.InputError>Enter valid list location</styledEl.InputError>}
+        {!isListUrlValid && listInput && <styledEl.InputError>Enter valid list location</styledEl.InputError>}
         {!isTokenAddressValid && <styledEl.InputError>Enter valid token address</styledEl.InputError>}
       </styledEl.PrimaryInputBox>
       {currentTab === 'lists' ? (
-        <ManageLists listSearchResponse={listSearchResponse} lists={lists} />
+        <ManageLists listSearchResponse={listSearchResponse} lists={lists} isListUrlValid={isListUrlValid} />
       ) : (
         <ManageTokens tokenSearchResponse={tokenSearchResponse} tokens={customTokens} />
       )}


### PR DESCRIPTION
# Summary

Fixes #4915 

The popup currently does not display an error message when a user enters a token list URL that fails to load.

This PR resolves the issue by managing the error within the `ManageLists` component through the introduction of a new prop, `isListUrlValid`.

The solution is intentionally designed to minimize changes to the existing business logic and component structure, so it might not fully align with the requested UI (an error message without a top border).

Screenshots and a video demonstrating the changes are attached.

![image](https://github.com/user-attachments/assets/23218b8b-75b1-4366-a25d-46b7e18a8f57)

https://github.com/user-attachments/assets/9a6cc5ec-1540-401d-85ce-1ef79780ebf7